### PR TITLE
feat: add Crisp push notification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,20 +79,29 @@ Nothing special to do for the chatbox itself.
 
 Crisp push notifications require credentials in your [Crisp dashboard](https://app.crisp.chat/) under **Settings > Chatbox Settings > Push Notifications** (APNs for iOS, Firebase for Android). See the [Crisp iOS](https://docs.crisp.chat/guides/chatbox-sdks/ios-sdk/) and [Crisp Android](https://docs.crisp.chat/guides/chatbox-sdks/android-sdk/) guides for dashboard setup.
 
-#### With `@capacitor/push-notifications` (recommended)
+#### Native setup (recommended)
+
+The plugin handles timing-sensitive setup natively:
+
+- **iOS**: APNs tokens from `@capacitor/push-notifications` are forwarded to Crisp automatically.
+- **Android**: `enableNotifications()` runs automatically inside `configure()`.
+
+You still need platform setup:
 
 1. Enable the **Push Notifications** capability in Xcode (iOS).
 2. Configure Firebase (`google-services.json`) and add `firebase-messaging` to your Android app (Android).
-3. After `configure()`, call `enableNotifications()` on Android.
-4. Forward the device token to Crisp:
+3. Call `CapacitorCrisp.configure({ websiteID: 'YOUR_WEBSITE_ID' })` before opening the messenger.
+
+#### With `@capacitor/push-notifications`
 
 ```typescript
 import { CapacitorCrisp } from '@capgo/capacitor-crisp';
 import { PushNotifications } from '@capacitor/push-notifications';
 
 await CapacitorCrisp.configure({ websiteID: 'YOUR_WEBSITE_ID' });
-await CapacitorCrisp.enableNotifications();
+await PushNotifications.register();
 
+// Optional JS fallback (iOS is already handled natively)
 await PushNotifications.addListener('registration', async ({ value }) => {
   await CapacitorCrisp.registerPushToken({ token: value });
 });
@@ -109,6 +118,30 @@ On iOS, disable Crisp auto-prompting if you manage permissions yourself:
 
 ```typescript
 await CapacitorCrisp.setShouldPromptForNotificationPermission({ enabled: false });
+```
+
+#### Android: shared FirebaseMessagingService
+
+If you already have a custom `FirebaseMessagingService`, forward Crisp events with `CrispFcmHelper`:
+
+```java
+import ee.forgr.plugin.crisp.CrispFcmHelper;
+import com.google.firebase.messaging.FirebaseMessagingService;
+import com.google.firebase.messaging.RemoteMessage;
+
+public class MyFirebaseMessagingService extends FirebaseMessagingService {
+    @Override
+    public void onMessageReceived(RemoteMessage remoteMessage) {
+        if (CrispFcmHelper.isCrispNotification(remoteMessage)) {
+            CrispFcmHelper.onMessageReceived(this, remoteMessage);
+        }
+    }
+
+    @Override
+    public void onNewToken(String token) {
+        CrispFcmHelper.onNewToken(this, token);
+    }
+}
 ```
 
 #### Android: Crisp-only notifications
@@ -355,8 +388,9 @@ registerPushToken(data: { token: string; }) => Promise<void>
 ```
 
 Register the device push token (APNs on iOS, FCM on Android) with Crisp.
-Call this after obtaining a token from `@capacitor/push-notifications` or your
-native push setup. Must be called after `configure()`.
+Optional fallback when you cannot use native token forwarding.
+On iOS, the plugin forwards APNs tokens from `@capacitor/push-notifications`
+automatically via native hooks.
 
 | Param      | Type                            | Description          |
 | ---------- | ------------------------------- | -------------------- |
@@ -372,8 +406,8 @@ enableNotifications() => Promise<void>
 ```
 
 Enable Crisp push notifications on Android.
-Must be called after `configure()` and before opening the messenger.
-No-op on iOS and web.
+Called automatically during `configure()` on Android.
+This JS method is an optional manual override. No-op on iOS and web.
 
 --------------------
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,70 @@ Privacy - Photo Library Additions Usage Description (NSPhotoLibraryAddUsageDescr
 to your app's Info.plist.
 
 ### Android Integration
-Nothing special to do.
+Nothing special to do for the chatbox itself.
+
+### Push Notifications
+
+Crisp push notifications require credentials in your [Crisp dashboard](https://app.crisp.chat/) under **Settings > Chatbox Settings > Push Notifications** (APNs for iOS, Firebase for Android). See the [Crisp iOS](https://docs.crisp.chat/guides/chatbox-sdks/ios-sdk/) and [Crisp Android](https://docs.crisp.chat/guides/chatbox-sdks/android-sdk/) guides for dashboard setup.
+
+#### With `@capacitor/push-notifications` (recommended)
+
+1. Enable the **Push Notifications** capability in Xcode (iOS).
+2. Configure Firebase (`google-services.json`) and add `firebase-messaging` to your Android app (Android).
+3. After `configure()`, call `enableNotifications()` on Android.
+4. Forward the device token to Crisp:
+
+```typescript
+import { CapacitorCrisp } from '@capgo/capacitor-crisp';
+import { PushNotifications } from '@capacitor/push-notifications';
+
+await CapacitorCrisp.configure({ websiteID: 'YOUR_WEBSITE_ID' });
+await CapacitorCrisp.enableNotifications();
+
+await PushNotifications.addListener('registration', async ({ value }) => {
+  await CapacitorCrisp.registerPushToken({ token: value });
+});
+
+await PushNotifications.addListener('pushNotificationActionPerformed', async (event) => {
+  const { isCrisp } = await CapacitorCrisp.isCrispPushNotification({ data: event.notification.data });
+  if (isCrisp) {
+    await CapacitorCrisp.handlePushNotification({ data: event.notification.data });
+  }
+});
+```
+
+On iOS, disable Crisp auto-prompting if you manage permissions yourself:
+
+```typescript
+await CapacitorCrisp.setShouldPromptForNotificationPermission({ enabled: false });
+```
+
+#### Android: Crisp-only notifications
+
+If you do not use another push provider, declare `CrispNotificationService` in your app `AndroidManifest.xml`:
+
+```xml
+<service
+  android:name="im.crisp.client.external.notification.CrispNotificationService"
+  android:exported="false">
+  <intent-filter>
+    <action android:name="com.google.firebase.MESSAGING_EVENT" />
+  </intent-filter>
+</service>
+```
+
+#### iOS: native AppDelegate (optional)
+
+You can also forward the APNs token directly in `AppDelegate.swift`:
+
+```swift
+import Crisp
+
+func application(_ application: UIApplication,
+                 didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    CrispSDK.setDeviceToken(deviceToken)
+}
+```
 
 
 ## Open chatbox
@@ -98,6 +161,12 @@ CapacitorCrisp.openMessenger()
 * [`sendMessage(...)`](#sendmessage)
 * [`setSegment(...)`](#setsegment)
 * [`reset()`](#reset)
+* [`registerPushToken(...)`](#registerpushtoken)
+* [`enableNotifications()`](#enablenotifications)
+* [`isCrispPushNotification(...)`](#iscrisppushnotification)
+* [`handlePushNotification(...)`](#handlepushnotification)
+* [`setShouldPromptForNotificationPermission(...)`](#setshouldpromptfornotificationpermission)
+* [`openChatboxFromNotification()`](#openchatboxfromnotification)
 * [`getPluginVersion()`](#getpluginversion)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
@@ -279,6 +348,102 @@ Useful when user logs out.
 --------------------
 
 
+### registerPushToken(...)
+
+```typescript
+registerPushToken(data: { token: string; }) => Promise<void>
+```
+
+Register the device push token (APNs on iOS, FCM on Android) with Crisp.
+Call this after obtaining a token from `@capacitor/push-notifications` or your
+native push setup. Must be called after `configure()`.
+
+| Param      | Type                            | Description          |
+| ---------- | ------------------------------- | -------------------- |
+| **`data`** | <code>{ token: string; }</code> | - Push token payload |
+
+--------------------
+
+
+### enableNotifications()
+
+```typescript
+enableNotifications() => Promise<void>
+```
+
+Enable Crisp push notifications on Android.
+Must be called after `configure()` and before opening the messenger.
+No-op on iOS and web.
+
+--------------------
+
+
+### isCrispPushNotification(...)
+
+```typescript
+isCrispPushNotification(data: { data: Record<string, string>; }) => Promise<{ isCrisp: boolean; }>
+```
+
+Check whether a push notification payload was sent by Crisp.
+Useful when sharing push handling with `@capacitor/push-notifications`.
+
+| Param      | Type                                                                       | Description            |
+| ---------- | -------------------------------------------------------------------------- | ---------------------- |
+| **`data`** | <code>{ data: <a href="#record">Record</a>&lt;string, string&gt;; }</code> | - Notification payload |
+
+**Returns:** <code>Promise&lt;{ isCrisp: boolean; }&gt;</code>
+
+--------------------
+
+
+### handlePushNotification(...)
+
+```typescript
+handlePushNotification(data: { data: Record<string, string>; openChatbox?: boolean; }) => Promise<void>
+```
+
+Handle a Crisp push notification payload.
+On Android, opens the chatbox by default when the user taps a notification.
+On iOS, processes the payload through the Crisp SDK.
+
+| Param      | Type                                                                                              | Description            |
+| ---------- | ------------------------------------------------------------------------------------------------- | ---------------------- |
+| **`data`** | <code>{ data: <a href="#record">Record</a>&lt;string, string&gt;; openChatbox?: boolean; }</code> | - Notification payload |
+
+--------------------
+
+
+### setShouldPromptForNotificationPermission(...)
+
+```typescript
+setShouldPromptForNotificationPermission(data: { enabled: boolean; }) => Promise<void>
+```
+
+Control whether Crisp auto-prompts for notification permission on iOS.
+No-op on Android and web.
+
+| Param      | Type                               | Description                 |
+| ---------- | ---------------------------------- | --------------------------- |
+| **`data`** | <code>{ enabled: boolean; }</code> | - Permission prompt options |
+
+--------------------
+
+
+### openChatboxFromNotification()
+
+```typescript
+openChatboxFromNotification() => Promise<{ opened: boolean; }>
+```
+
+Open the Crisp chatbox from a notification tap intent on Android.
+Call from your main activity when handling notification open actions.
+No-op on iOS and web.
+
+**Returns:** <code>Promise&lt;{ opened: boolean; }&gt;</code>
+
+--------------------
+
+
 ### getPluginVersion()
 
 ```typescript
@@ -315,5 +480,12 @@ Available colors for Crisp events.
 Used to visually categorize events in the Crisp dashboard.
 
 <code>'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'purple' | 'pink' | 'brown' | 'grey' | 'black'</code>
+
+
+#### Record
+
+Construct a type with a set of properties K of type T
+
+<code>{ [P in K]: T; }</code>
 
 </docgen-api>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     implementation 'im.crisp:crisp-sdk:2.0.21'
+    compileOnly 'com.google.firebase:firebase-messaging:24.1.0'
     implementation 'androidx.multidex:multidex:2.0.1'
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/src/main/java/ee/forgr/plugin/crisp/CapacitorCrispPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/crisp/CapacitorCrispPlugin.java
@@ -16,9 +16,13 @@ import im.crisp.client.external.data.Company;
 import im.crisp.client.external.data.Employment;
 import im.crisp.client.external.data.Geolocation;
 import im.crisp.client.external.data.SessionEvent;
+import im.crisp.client.external.notification.CrispNotificationClient;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Locale;
+import java.util.Map;
 import org.json.JSONException;
 
 @CapacitorPlugin(name = "CapacitorCrisp")
@@ -227,6 +231,68 @@ public class CapacitorCrispPlugin extends Plugin {
     public void reset(PluginCall call) {
         Crisp.resetChatSession(this.getCrispContext());
         call.resolve();
+    }
+
+    public void registerPushToken(PluginCall call) {
+        String token = call.getString("token");
+        if (token == null || token.isEmpty()) {
+            call.reject("token is required");
+            return;
+        }
+        CrispNotificationClient.sendTokenToCrisp(this.getCrispContext(), token);
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void enableNotifications(PluginCall call) {
+        Crisp.enableNotifications(this.getCrispContext(), true);
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void isCrispPushNotification(PluginCall call) {
+        Map<String, String> data = this.getNotificationData(call);
+        JSObject ret = new JSObject();
+        ret.put("isCrisp", CrispNotificationClient.isCrispNotification(data));
+        call.resolve(ret);
+    }
+
+    @PluginMethod
+    public void handlePushNotification(PluginCall call) {
+        Map<String, String> data = this.getNotificationData(call);
+        boolean openChatbox = call.getBoolean("openChatbox", true);
+        CrispNotificationClient.handleNotification(this.getCrispContext(), data, openChatbox);
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void setShouldPromptForNotificationPermission(PluginCall call) {
+        call.resolve();
+    }
+
+    @PluginMethod
+    public void openChatboxFromNotification(PluginCall call) {
+        boolean opened = false;
+        if (this.getActivity() != null) {
+            opened = CrispNotificationClient.openChatbox(this.getActivity(), this.getActivity().getIntent());
+        }
+        JSObject ret = new JSObject();
+        ret.put("opened", opened);
+        call.resolve(ret);
+    }
+
+    private Map<String, String> getNotificationData(PluginCall call) {
+        JSObject data = call.getObject("data");
+        Map<String, String> map = new HashMap<>();
+        if (data == null) {
+            return map;
+        }
+        Iterator<String> keys = data.keys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            map.put(key, data.optString(key));
+        }
+        return map;
     }
 
     @PluginMethod

--- a/android/src/main/java/ee/forgr/plugin/crisp/CapacitorCrispPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/crisp/CapacitorCrispPlugin.java
@@ -89,6 +89,7 @@ public class CapacitorCrispPlugin extends Plugin {
         } else {
             Crisp.configure(crispContext, websiteID);
         }
+        Crisp.enableNotifications(crispContext, true);
         call.resolve();
     }
 
@@ -233,6 +234,7 @@ public class CapacitorCrispPlugin extends Plugin {
         call.resolve();
     }
 
+    @PluginMethod
     public void registerPushToken(PluginCall call) {
         String token = call.getString("token");
         if (token == null || token.isEmpty()) {

--- a/android/src/main/java/ee/forgr/plugin/crisp/CrispFcmHelper.java
+++ b/android/src/main/java/ee/forgr/plugin/crisp/CrispFcmHelper.java
@@ -1,0 +1,58 @@
+package ee.forgr.plugin.crisp;
+
+import android.content.Context;
+import android.util.Log;
+import androidx.annotation.NonNull;
+import com.google.firebase.messaging.RemoteMessage;
+import im.crisp.client.external.notification.CrispNotificationClient;
+import java.util.Map;
+
+/**
+ * Static helper for routing Firebase Cloud Messaging events to Crisp.
+ *
+ * <p>Android allows only one {@code FirebaseMessagingService}, so your app must
+ * create its own service and call these methods to forward Crisp pushes.
+ *
+ * <pre>{@code
+ * public class MyFirebaseMessagingService extends FirebaseMessagingService {
+ *
+ *     @Override
+ *     public void onMessageReceived(RemoteMessage remoteMessage) {
+ *         if (CrispFcmHelper.isCrispNotification(remoteMessage)) {
+ *             CrispFcmHelper.onMessageReceived(this, remoteMessage);
+ *         }
+ *     }
+ *
+ *     @Override
+ *     public void onNewToken(String token) {
+ *         CrispFcmHelper.onNewToken(this, token);
+ *     }
+ * }
+ * }</pre>
+ */
+public final class CrispFcmHelper {
+
+    private static final String TAG = "CrispFcmHelper";
+
+    private CrispFcmHelper() {}
+
+    public static boolean isCrispNotification(@NonNull RemoteMessage remoteMessage) {
+        return CrispNotificationClient.isCrispNotification(remoteMessage);
+    }
+
+    public static boolean isCrispNotification(@NonNull Map<String, String> data) {
+        return CrispNotificationClient.isCrispNotification(data);
+    }
+
+    public static void onMessageReceived(@NonNull Context context, @NonNull RemoteMessage remoteMessage) {
+        if (CrispNotificationClient.isCrispNotification(remoteMessage)) {
+            Log.d(TAG, "Handling Crisp push");
+            CrispNotificationClient.handleNotification(context, remoteMessage);
+        }
+    }
+
+    public static void onNewToken(@NonNull Context context, @NonNull String token) {
+        Log.d(TAG, "Forwarding FCM token to Crisp");
+        CrispNotificationClient.sendTokenToCrisp(context, token);
+    }
+}

--- a/ios/Sources/CapacitorCrispPlugin/CapacitorCrispPlugin.swift
+++ b/ios/Sources/CapacitorCrispPlugin/CapacitorCrispPlugin.swift
@@ -23,6 +23,12 @@ public class CapacitorCrispPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "setInt", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "setSegment", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "reset", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "registerPushToken", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "enableNotifications", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "isCrispPushNotification", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "handlePushNotification", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setShouldPromptForNotificationPermission", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "openChatboxFromNotification", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise)
     ]
     @objc override public func load() {
@@ -168,8 +174,87 @@ public class CapacitorCrispPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
+    @objc func registerPushToken(_ call: CAPPluginCall) {
+        guard let token = call.getString("token"), !token.isEmpty else {
+            call.reject("token is required")
+            return
+        }
+        guard let deviceToken = self.dataFromPushToken(token) else {
+            call.reject("Invalid push token format")
+            return
+        }
+        DispatchQueue.main.async {
+            CrispSDK.setDeviceToken(deviceToken)
+            call.resolve()
+        }
+    }
+
+
+    @objc func enableNotifications(_ call: CAPPluginCall) {
+        call.resolve()
+    }
+
+    @objc func isCrispPushNotification(_ call: CAPPluginCall) {
+        let payload = self.payloadFromCall(call)
+        let isCrisp = CrispSDK._isRawCrispPushNotification(payload)
+        call.resolve(["isCrisp": isCrisp])
+    }
+
+    @objc func handlePushNotification(_ call: CAPPluginCall) {
+        let payload = self.payloadFromCall(call)
+        DispatchQueue.main.async {
+            CrispSDK._handleRawPushNotification(payload)
+            call.resolve()
+        }
+    }
+
+    @objc func setShouldPromptForNotificationPermission(_ call: CAPPluginCall) {
+        let enabled = call.getBool("enabled") ?? true
+        DispatchQueue.main.async {
+            CrispSDK.setShouldPromptForNotificationPermission(enabled)
+            call.resolve()
+        }
+    }
+
+    @objc func openChatboxFromNotification(_ call: CAPPluginCall) {
+        call.resolve(["opened": false])
+    }
+
     @objc func getPluginVersion(_ call: CAPPluginCall) {
         call.resolve(["version": self.pluginVersion])
+    }
+
+    private func dataFromPushToken(_ token: String) -> Data? {
+        let cleaned = token
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "<", with: "")
+            .replacingOccurrences(of: ">", with: "")
+        guard !cleaned.isEmpty, cleaned.count % 2 == 0 else {
+            return nil
+        }
+
+        var data = Data(capacity: cleaned.count / 2)
+        var index = cleaned.startIndex
+        while index < cleaned.endIndex {
+            let next = cleaned.index(index, offsetBy: 2)
+            guard next <= cleaned.endIndex, let byte = UInt8(cleaned[index..<next], radix: 16) else {
+                return nil
+            }
+            data.append(byte)
+            index = next
+        }
+        return data
+    }
+
+    private func payloadFromCall(_ call: CAPPluginCall) -> [AnyHashable: Any] {
+        guard let data = call.getObject("data") else {
+            return [:]
+        }
+        var payload: [AnyHashable: Any] = [:]
+        for (key, value) in data {
+            payload[key] = value
+        }
+        return payload
     }
 
 }

--- a/ios/Sources/CapacitorCrispPlugin/CapacitorCrispPlugin.swift
+++ b/ios/Sources/CapacitorCrispPlugin/CapacitorCrispPlugin.swift
@@ -9,6 +9,7 @@ import Crisp
 @objc(CapacitorCrispPlugin)
 public class CapacitorCrispPlugin: CAPPlugin, CAPBridgedPlugin {
     private let pluginVersion: String = "8.0.38"
+    private var pushObserver: NSObjectProtocol?
     public let identifier = "CapacitorCrispPlugin"
     public let jsName = "CapacitorCrisp"
     public let pluginMethods: [CAPPluginMethod] = [
@@ -32,8 +33,22 @@ public class CapacitorCrispPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise)
     ]
     @objc override public func load() {
-        // Called when the plugin is first constructed in the bridge
-        print("CapacitorCrispPlugin Initialized")
+        pushObserver = NotificationCenter.default.addObserver(
+            forName: .capacitorDidRegisterForRemoteNotifications,
+            object: nil,
+            queue: .main
+        ) { notification in
+            guard let deviceToken = notification.object as? Data else {
+                return
+            }
+            CrispSDK.setDeviceToken(deviceToken)
+        }
+    }
+
+    deinit {
+        if let observer = pushObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
     }
 
     @objc func configure(_ call: CAPPluginCall) {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -209,27 +209,20 @@ export interface CapacitorCrispPlugin {
 
   /**
    * Register the device push token (APNs on iOS, FCM on Android) with Crisp.
-   * Call this after obtaining a token from `@capacitor/push-notifications` or your
-   * native push setup. Must be called after `configure()`.
+   * Optional fallback when you cannot use native token forwarding.
+   * On iOS, the plugin forwards APNs tokens from `@capacitor/push-notifications`
+   * automatically via native hooks.
    *
    * @param data - Push token payload
    * @param data.token - Device push token string
    * @returns Promise that resolves when the token is registered
-   * @example
-   * ```typescript
-   * import { PushNotifications } from '@capacitor/push-notifications';
-   *
-   * await PushNotifications.addListener('registration', async ({ value }) => {
-   *   await CapacitorCrisp.registerPushToken({ token: value });
-   * });
-   * ```
    */
   registerPushToken(data: { token: string }): Promise<void>;
 
   /**
    * Enable Crisp push notifications on Android.
-   * Must be called after `configure()` and before opening the messenger.
-   * No-op on iOS and web.
+   * Called automatically during `configure()` on Android.
+   * This JS method is an optional manual override. No-op on iOS and web.
    *
    * @returns Promise that resolves when notifications are enabled
    */

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -208,6 +208,75 @@ export interface CapacitorCrispPlugin {
   reset(): Promise<void>;
 
   /**
+   * Register the device push token (APNs on iOS, FCM on Android) with Crisp.
+   * Call this after obtaining a token from `@capacitor/push-notifications` or your
+   * native push setup. Must be called after `configure()`.
+   *
+   * @param data - Push token payload
+   * @param data.token - Device push token string
+   * @returns Promise that resolves when the token is registered
+   * @example
+   * ```typescript
+   * import { PushNotifications } from '@capacitor/push-notifications';
+   *
+   * await PushNotifications.addListener('registration', async ({ value }) => {
+   *   await CapacitorCrisp.registerPushToken({ token: value });
+   * });
+   * ```
+   */
+  registerPushToken(data: { token: string }): Promise<void>;
+
+  /**
+   * Enable Crisp push notifications on Android.
+   * Must be called after `configure()` and before opening the messenger.
+   * No-op on iOS and web.
+   *
+   * @returns Promise that resolves when notifications are enabled
+   */
+  enableNotifications(): Promise<void>;
+
+  /**
+   * Check whether a push notification payload was sent by Crisp.
+   * Useful when sharing push handling with `@capacitor/push-notifications`.
+   *
+   * @param data - Notification payload
+   * @param data.data - Key/value data from the push notification
+   * @returns Promise resolving to whether the notification is from Crisp
+   */
+  isCrispPushNotification(data: { data: Record<string, string> }): Promise<{ isCrisp: boolean }>;
+
+  /**
+   * Handle a Crisp push notification payload.
+   * On Android, opens the chatbox by default when the user taps a notification.
+   * On iOS, processes the payload through the Crisp SDK.
+   *
+   * @param data - Notification payload
+   * @param data.data - Key/value data from the push notification
+   * @param data.openChatbox - Android only. Open the chatbox after handling. Defaults to true.
+   * @returns Promise that resolves when the notification is handled
+   */
+  handlePushNotification(data: { data: Record<string, string>; openChatbox?: boolean }): Promise<void>;
+
+  /**
+   * Control whether Crisp auto-prompts for notification permission on iOS.
+   * No-op on Android and web.
+   *
+   * @param data - Permission prompt options
+   * @param data.enabled - When false, Crisp will not prompt for notification permission
+   * @returns Promise that resolves when the preference is applied
+   */
+  setShouldPromptForNotificationPermission(data: { enabled: boolean }): Promise<void>;
+
+  /**
+   * Open the Crisp chatbox from a notification tap intent on Android.
+   * Call from your main activity when handling notification open actions.
+   * No-op on iOS and web.
+   *
+   * @returns Promise resolving to whether a Crisp chatbox was opened
+   */
+  openChatboxFromNotification(): Promise<{ opened: boolean }>;
+
+  /**
    * Get the plugin version number.
    *
    * @returns Promise with version string

--- a/src/web.ts
+++ b/src/web.ts
@@ -166,6 +166,30 @@ export class CapacitorCrispWeb extends WebPlugin implements CapacitorCrispPlugin
     this.setAutoHide();
   }
 
+  async registerPushToken(_data: { token: string }): Promise<void> {
+    throw this.unimplemented('Push notifications are not available on web.');
+  }
+
+  async enableNotifications(): Promise<void> {
+    throw this.unimplemented('Push notifications are not available on web.');
+  }
+
+  async isCrispPushNotification(_data: { data: Record<string, string> }): Promise<{ isCrisp: boolean }> {
+    return { isCrisp: false };
+  }
+
+  async handlePushNotification(_data: { data: Record<string, string>; openChatbox?: boolean }): Promise<void> {
+    throw this.unimplemented('Push notifications are not available on web.');
+  }
+
+  async setShouldPromptForNotificationPermission(_data: { enabled: boolean }): Promise<void> {
+    throw this.unimplemented('Push notifications are not available on web.');
+  }
+
+  async openChatboxFromNotification(): Promise<{ opened: boolean }> {
+    return { opened: false };
+  }
+
   async getPluginVersion(): Promise<{ version: string }> {
     return { version: 'web' };
   }


### PR DESCRIPTION
## Summary
- Adds push notification APIs to bridge Crisp native SDK with Capacitor apps: `registerPushToken`, `enableNotifications`, `isCrispPushNotification`, `handlePushNotification`, `setShouldPromptForNotificationPermission`, and `openChatboxFromNotification`
- Documents setup for Crisp dashboard credentials, `@capacitor/push-notifications` coexistence, and Android Crisp-only mode
- Fixes #177

## Test plan
- [x] `bun run verify` passes locally (iOS, Android, web)
- [ ] Configure APNs/FCM in Crisp dashboard and verify token registration on a physical device
- [ ] Confirm Crisp chat notifications arrive when app is backgrounded
- [ ] Verify notification tap opens Crisp chat via `handlePushNotification`


Made with [Cursor](https://cursor.com)