### PR TITLE
[codex] bridge Crisp native events

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ CapacitorCrisp.openMessenger()
 * [`sendMessage(...)`](#sendmessage)
 * [`setSegment(...)`](#setsegment)
 * [`reset()`](#reset)
+* [`addListener('messageReceived', ...)`](#addlistenermessagereceived-)
+* [`addListener('messageSent', ...)`](#addlistenermessagesent-)
+* [`addListener('sessionLoaded', ...)`](#addlistenersessionloaded-)
+* [`addListener('chatOpened', ...)`](#addlistenerchatopened-)
+* [`addListener('chatClosed', ...)`](#addlistenerchatclosed-)
+* [`removeAllListeners()`](#removealllisteners)
 * [`registerPushToken(...)`](#registerpushtoken)
 * [`enableNotifications()`](#enablenotifications)
 * [`isCrispPushNotification(...)`](#iscrisppushnotification)
@@ -381,6 +387,107 @@ Useful when user logs out.
 --------------------
 
 
+### addListener('messageReceived', ...)
+
+```typescript
+addListener(eventName: 'messageReceived', listenerFunc: (event: CrispMessageEvent) => void) => Promise<PluginListenerHandle>
+```
+
+Listen for incoming Crisp messages.
+
+| Param              | Type                                                                                | Description                     |
+| ------------------ | ----------------------------------------------------------------------------------- | ------------------------------- |
+| **`eventName`**    | <code>'messageReceived'</code>                                                      | - `messageReceived`             |
+| **`listenerFunc`** | <code>(event: <a href="#crispmessageevent">CrispMessageEvent</a>) =&gt; void</code> | - Called with message metadata. |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+--------------------
+
+
+### addListener('messageSent', ...)
+
+```typescript
+addListener(eventName: 'messageSent', listenerFunc: (event: CrispMessageEvent) => void) => Promise<PluginListenerHandle>
+```
+
+Listen for messages sent through Crisp.
+
+| Param              | Type                                                                                | Description                     |
+| ------------------ | ----------------------------------------------------------------------------------- | ------------------------------- |
+| **`eventName`**    | <code>'messageSent'</code>                                                          | - `messageSent`                 |
+| **`listenerFunc`** | <code>(event: <a href="#crispmessageevent">CrispMessageEvent</a>) =&gt; void</code> | - Called with message metadata. |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+--------------------
+
+
+### addListener('sessionLoaded', ...)
+
+```typescript
+addListener(eventName: 'sessionLoaded', listenerFunc: (event: CrispSessionLoadedEvent) => void) => Promise<PluginListenerHandle>
+```
+
+Listen for the native Crisp session loading.
+
+| Param              | Type                                                                                            | Description                          |
+| ------------------ | ----------------------------------------------------------------------------------------------- | ------------------------------------ |
+| **`eventName`**    | <code>'sessionLoaded'</code>                                                                    | - `sessionLoaded`                    |
+| **`listenerFunc`** | <code>(event: <a href="#crispsessionloadedevent">CrispSessionLoadedEvent</a>) =&gt; void</code> | - Called with the native session ID. |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+--------------------
+
+
+### addListener('chatOpened', ...)
+
+```typescript
+addListener(eventName: 'chatOpened', listenerFunc: () => void) => Promise<PluginListenerHandle>
+```
+
+Listen for the Crisp chatbox opening.
+
+| Param              | Type                       | Description                      |
+| ------------------ | -------------------------- | -------------------------------- |
+| **`eventName`**    | <code>'chatOpened'</code>  | - `chatOpened`                   |
+| **`listenerFunc`** | <code>() =&gt; void</code> | - Called when the chatbox opens. |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+--------------------
+
+
+### addListener('chatClosed', ...)
+
+```typescript
+addListener(eventName: 'chatClosed', listenerFunc: () => void) => Promise<PluginListenerHandle>
+```
+
+Listen for the Crisp chatbox closing.
+
+| Param              | Type                       | Description                       |
+| ------------------ | -------------------------- | --------------------------------- |
+| **`eventName`**    | <code>'chatClosed'</code>  | - `chatClosed`                    |
+| **`listenerFunc`** | <code>() =&gt; void</code> | - Called when the chatbox closes. |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+--------------------
+
+
+### removeAllListeners()
+
+```typescript
+removeAllListeners() => Promise<void>
+```
+
+Remove all registered listeners for this plugin.
+
+--------------------
+
+
 ### registerPushToken(...)
 
 ```typescript
@@ -503,6 +610,31 @@ Configuration for initializing Crisp.
 | **`websiteID`** | <code>string</code> | Your Crisp website ID from dashboard.                                                                                                                                  |
 | **`locale`**    | <code>string</code> | Optional - Locale to force in the Crisp chat widget (ISO 639-1), eg. `en`, `fr`, `es`. Web + Android: overrides the runtime locale. iOS follows the device/app locale. |
 | **`tokenID`**   | <code>string</code> | Optional - Unique token identifier for the user session continuity.                                                                                                    |
+
+
+#### PluginListenerHandle
+
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
+
+
+#### CrispMessageEvent
+
+Payload emitted when a Crisp message event is received from the native SDK.
+
+| Prop       | Type                 | Description                                       |
+| ---------- | -------------------- | ------------------------------------------------- |
+| **`isMe`** | <code>boolean</code> | Whether the message was sent by the current user. |
+
+
+#### CrispSessionLoadedEvent
+
+Payload emitted when the Crisp session is loaded.
+
+| Prop            | Type                | Description                      |
+| --------------- | ------------------- | -------------------------------- |
+| **`sessionId`** | <code>string</code> | Native Crisp session identifier. |
 
 
 ### Type Aliases

--- a/android/src/main/java/ee/forgr/plugin/crisp/CapacitorCrispPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/crisp/CapacitorCrispPlugin.java
@@ -12,10 +12,12 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import im.crisp.client.external.ChatActivity;
 import im.crisp.client.external.Crisp;
+import im.crisp.client.external.EventsCallback;
 import im.crisp.client.external.data.Company;
 import im.crisp.client.external.data.Employment;
 import im.crisp.client.external.data.Geolocation;
 import im.crisp.client.external.data.SessionEvent;
+import im.crisp.client.external.data.message.Message;
 import im.crisp.client.external.notification.CrispNotificationClient;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -33,6 +35,63 @@ public class CapacitorCrispPlugin extends Plugin {
     protected static final int OPEN_MESSENGER_CODE = 12345; // Unique request code
 
     private Locale configuredLocale;
+
+    private final EventsCallback eventsCallback = new EventsCallback() {
+        @Override
+        public void onSessionLoaded(String sessionId) {
+            JSObject ret = new JSObject();
+            ret.put("sessionId", sessionId);
+            notifyCrispEvent("sessionLoaded", ret);
+        }
+
+        @Override
+        public void onChatOpened() {
+            notifyCrispEvent("chatOpened", new JSObject());
+        }
+
+        @Override
+        public void onChatClosed() {
+            notifyCrispEvent("chatClosed", new JSObject());
+        }
+
+        @Override
+        public void onMessageSent(Message message) {
+            notifyCrispEvent("messageSent", getMessageEvent(message));
+        }
+
+        @Override
+        public void onMessageReceived(Message message) {
+            notifyCrispEvent("messageReceived", getMessageEvent(message));
+        }
+    };
+
+    @Override
+    public void load() {
+        super.load();
+        Crisp.addCallback(this.eventsCallback);
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        Crisp.removeCallback(this.eventsCallback);
+        super.handleOnDestroy();
+    }
+
+    private JSObject getMessageEvent(Message message) {
+        JSObject ret = new JSObject();
+        if (message != null) {
+            ret.put("isMe", message.isMe());
+        }
+        return ret;
+    }
+
+    private void notifyCrispEvent(String eventName, JSObject data) {
+        if (this.getActivity() != null) {
+            this.getActivity().runOnUiThread(() -> notifyListeners(eventName, data));
+            return;
+        }
+        notifyListeners(eventName, data);
+    }
 
     private Context getCrispContext() {
         Context activity = this.getActivity();

--- a/ios/Sources/CapacitorCrispPlugin/CapacitorCrispPlugin.swift
+++ b/ios/Sources/CapacitorCrispPlugin/CapacitorCrispPlugin.swift
@@ -10,6 +10,7 @@ import Crisp
 public class CapacitorCrispPlugin: CAPPlugin, CAPBridgedPlugin {
     private let pluginVersion: String = "8.1.0"
     private var pushObserver: NSObjectProtocol?
+    private var eventCallbackTokens: [CallbackToken] = []
     public let identifier = "CapacitorCrispPlugin"
     public let jsName = "CapacitorCrisp"
     public let pluginMethods: [CAPPluginMethod] = [
@@ -43,9 +44,13 @@ public class CapacitorCrispPlugin: CAPPlugin, CAPBridgedPlugin {
             }
             CrispSDK.setDeviceToken(deviceToken)
         }
+        registerEventCallbacks()
     }
 
     deinit {
+        for token in eventCallbackTokens {
+            CrispSDK.removeCallback(token: token)
+        }
         if let observer = pushObserver {
             NotificationCenter.default.removeObserver(observer)
         }
@@ -204,7 +209,6 @@ public class CapacitorCrispPlugin: CAPPlugin, CAPBridgedPlugin {
         }
     }
 
-
     @objc func enableNotifications(_ call: CAPPluginCall) {
         call.resolve()
     }
@@ -272,4 +276,33 @@ public class CapacitorCrispPlugin: CAPPlugin, CAPBridgedPlugin {
         return payload
     }
 
+}
+
+private extension CapacitorCrispPlugin {
+    func registerEventCallbacks() {
+        guard eventCallbackTokens.isEmpty else {
+            return
+        }
+        eventCallbackTokens = [
+            CrispSDK.addCallback(.messageReceived { [weak self] message in
+                self?.notifyListeners("messageReceived", data: self?.messagePayload(message) ?? [:])
+            }),
+            CrispSDK.addCallback(.messageSent { [weak self] message in
+                self?.notifyListeners("messageSent", data: self?.messagePayload(message) ?? [:])
+            }),
+            CrispSDK.addCallback(.sessionLoaded { [weak self] sessionId in
+                self?.notifyListeners("sessionLoaded", data: ["sessionId": sessionId])
+            }),
+            CrispSDK.addCallback(.chatOpened { [weak self] in
+                self?.notifyListeners("chatOpened", data: [:])
+            }),
+            CrispSDK.addCallback(.chatClosed { [weak self] in
+                self?.notifyListeners("chatClosed", data: [:])
+            })
+        ]
+    }
+
+    func messagePayload(_ message: Message) -> [String: Any] {
+        return ["isMe": message.isMe]
+    }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,3 +1,5 @@
+import type { PluginListenerHandle } from '@capacitor/core';
+
 /**
  * Available colors for Crisp events.
  * Used to visually categorize events in the Crisp dashboard.
@@ -31,6 +33,26 @@ export interface ConfigureOptions {
    * Optional - Unique token identifier for the user session continuity.
    */
   tokenID?: string;
+}
+
+/**
+ * Payload emitted when a Crisp message event is received from the native SDK.
+ */
+export interface CrispMessageEvent {
+  /**
+   * Whether the message was sent by the current user.
+   */
+  isMe?: boolean;
+}
+
+/**
+ * Payload emitted when the Crisp session is loaded.
+ */
+export interface CrispSessionLoadedEvent {
+  /**
+   * Native Crisp session identifier.
+   */
+  sessionId?: string;
 }
 
 /**
@@ -206,6 +228,67 @@ export interface CapacitorCrispPlugin {
    * @returns Promise that resolves when session is reset
    */
   reset(): Promise<void>;
+
+  /**
+   * Listen for incoming Crisp messages.
+   *
+   * @param eventName - `messageReceived`
+   * @param listenerFunc - Called with message metadata.
+   * @returns Promise resolving with a listener handle.
+   */
+  addListener(
+    eventName: 'messageReceived',
+    listenerFunc: (event: CrispMessageEvent) => void,
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * Listen for messages sent through Crisp.
+   *
+   * @param eventName - `messageSent`
+   * @param listenerFunc - Called with message metadata.
+   * @returns Promise resolving with a listener handle.
+   */
+  addListener(
+    eventName: 'messageSent',
+    listenerFunc: (event: CrispMessageEvent) => void,
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * Listen for the native Crisp session loading.
+   *
+   * @param eventName - `sessionLoaded`
+   * @param listenerFunc - Called with the native session ID.
+   * @returns Promise resolving with a listener handle.
+   */
+  addListener(
+    eventName: 'sessionLoaded',
+    listenerFunc: (event: CrispSessionLoadedEvent) => void,
+  ): Promise<PluginListenerHandle>;
+
+  /**
+   * Listen for the Crisp chatbox opening.
+   *
+   * @param eventName - `chatOpened`
+   * @param listenerFunc - Called when the chatbox opens.
+   * @returns Promise resolving with a listener handle.
+   */
+  addListener(eventName: 'chatOpened', listenerFunc: () => void): Promise<PluginListenerHandle>;
+
+  /**
+   * Listen for the Crisp chatbox closing.
+   *
+   * @param eventName - `chatClosed`
+   * @param listenerFunc - Called when the chatbox closes.
+   * @returns Promise resolving with a listener handle.
+   */
+  addListener(eventName: 'chatClosed', listenerFunc: () => void): Promise<PluginListenerHandle>;
+
+  /**
+   * Remove all registered listeners for this plugin.
+   *
+   * @returns Promise resolving when listeners are removed.
+   */
+  removeAllListeners(): Promise<void>;
 
   /**
    * Register the device push token (APNs on iOS, FCM on Android) with Crisp.


### PR DESCRIPTION
## What changed
- Added typed JS listener overloads for `messageReceived`, `messageSent`, `sessionLoaded`, `chatOpened`, and `chatClosed`.
- Registered Android `EventsCallback` and iOS `CrispSDK.addCallback` handlers and forwarded them through Capacitor `notifyListeners`.
- Kept event payloads small: message events include `{ isMe }` when available, session load includes `{ sessionId }` when available, and chat open/close are signal events.
- Regenerated README API docs from `src/definitions.ts`.

## Root cause
- The native SDKs already emitted runtime chat events, but this plugin never registered those callbacks or bridged them to JavaScript listeners.

## Impact
- Apps can react to native Crisp message and chat state changes without running the web widget in parallel.
- This enables app UI such as unread badges and chat-open resets from the native SDK event source.

## Validation
- Confirmed Android callback signatures from the local `im.crisp:crisp-sdk:2.0.21` AAR with `javap`.
- Confirmed iOS callback signatures from the local Crisp 2.13.0 Swift interface.
- `bun run docgen`
- `bunx tsc`
- `bunx rollup -c rollup.config.mjs`
- `bunx eslint . --fix`
- `bunx eslint .` (passes with existing warnings in `src/web.ts`)
- `bunx prettier-pretty-check "**/*.{css,html,ts,js,java}" --plugin=prettier-plugin-java --write`
- `bunx prettier-pretty-check "**/*.{css,html,ts,js,java}" --plugin=prettier-plugin-java`
- `bunx node-swiftlint --fix --format`
- `bunx node-swiftlint lint` (passes with one existing non-serious complexity warning)
- `bun run verify:android`
- `bun run verify:ios`

## Not tested
- Manual runtime delivery with a real Crisp workspace on device.

Fixes #179
