### PR TITLE
fix: emit messageReceived from Crisp push payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ await PushNotifications.addListener('registration', async ({ value }) => {
   await CapacitorCrisp.registerPushToken({ token: value });
 });
 
+// Forward foreground Crisp pushes so messageReceived can update your unread badge.
+await PushNotifications.addListener('pushNotificationReceived', async (notification) => {
+  const { isCrisp } = await CapacitorCrisp.isCrispPushNotification({ data: notification.data });
+  if (isCrisp) {
+    await CapacitorCrisp.handlePushNotification({ data: notification.data, openChatbox: false });
+  }
+});
+
 await PushNotifications.addListener('pushNotificationActionPerformed', async (event) => {
   const { isCrisp } = await CapacitorCrisp.isCrispPushNotification({ data: event.notification.data });
   if (isCrisp) {
@@ -546,6 +554,8 @@ handlePushNotification(data: { data: Record<string, string>; openChatbox?: boole
 Handle a Crisp push notification payload.
 On Android, opens the chatbox by default when the user taps a notification.
 On iOS, processes the payload through the Crisp SDK.
+Emits `messageReceived` with `fromPushNotification: true` for Crisp payloads,
+which lets apps update unread badges when the chatbox is closed.
 
 | Param      | Type                                                                                              | Description            |
 | ---------- | ------------------------------------------------------------------------------------------------- | ---------------------- |
@@ -621,11 +631,13 @@ Configuration for initializing Crisp.
 
 #### CrispMessageEvent
 
-Payload emitted when a Crisp message event is received from the native SDK.
+Payload emitted when a Crisp message event is received from the native SDK
+or from a forwarded Crisp push notification.
 
-| Prop       | Type                 | Description                                       |
-| ---------- | -------------------- | ------------------------------------------------- |
-| **`isMe`** | <code>boolean</code> | Whether the message was sent by the current user. |
+| Prop                       | Type                 | Description                                                               |
+| -------------------------- | -------------------- | ------------------------------------------------------------------------- |
+| **`isMe`**                 | <code>boolean</code> | Whether the message was sent by the current user.                         |
+| **`fromPushNotification`** | <code>boolean</code> | True when the event was emitted from a forwarded Crisp push notification. |
 
 
 #### CrispSessionLoadedEvent

--- a/android/src/main/java/ee/forgr/plugin/crisp/CapacitorCrispPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/crisp/CapacitorCrispPlugin.java
@@ -85,6 +85,13 @@ public class CapacitorCrispPlugin extends Plugin {
         return ret;
     }
 
+    private JSObject getPushMessageEvent() {
+        JSObject ret = new JSObject();
+        ret.put("isMe", false);
+        ret.put("fromPushNotification", true);
+        return ret;
+    }
+
     private void notifyCrispEvent(String eventName, JSObject data) {
         if (this.getActivity() != null) {
             this.getActivity().runOnUiThread(() -> notifyListeners(eventName, data));
@@ -322,7 +329,11 @@ public class CapacitorCrispPlugin extends Plugin {
     public void handlePushNotification(PluginCall call) {
         Map<String, String> data = this.getNotificationData(call);
         boolean openChatbox = call.getBoolean("openChatbox", true);
+        boolean isCrisp = CrispNotificationClient.isCrispNotification(data);
         CrispNotificationClient.handleNotification(this.getCrispContext(), data, openChatbox);
+        if (isCrisp && !openChatbox) {
+            notifyCrispEvent("messageReceived", getPushMessageEvent());
+        }
         call.resolve();
     }
 

--- a/ios/Sources/CapacitorCrispPlugin/CapacitorCrispPlugin.swift
+++ b/ios/Sources/CapacitorCrispPlugin/CapacitorCrispPlugin.swift
@@ -221,8 +221,12 @@ public class CapacitorCrispPlugin: CAPPlugin, CAPBridgedPlugin {
 
     @objc func handlePushNotification(_ call: CAPPluginCall) {
         let payload = self.payloadFromCall(call)
+        let isCrisp = CrispSDK._isRawCrispPushNotification(payload)
         DispatchQueue.main.async {
             CrispSDK._handleRawPushNotification(payload)
+            if isCrisp {
+                self.notifyListeners("messageReceived", data: ["isMe": false, "fromPushNotification": true])
+            }
             call.resolve()
         }
     }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -36,13 +36,18 @@ export interface ConfigureOptions {
 }
 
 /**
- * Payload emitted when a Crisp message event is received from the native SDK.
+ * Payload emitted when a Crisp message event is received from the native SDK
+ * or from a forwarded Crisp push notification.
  */
 export interface CrispMessageEvent {
   /**
    * Whether the message was sent by the current user.
    */
   isMe?: boolean;
+  /**
+   * True when the event was emitted from a forwarded Crisp push notification.
+   */
+  fromPushNotification?: boolean;
 }
 
 /**
@@ -325,6 +330,8 @@ export interface CapacitorCrispPlugin {
    * Handle a Crisp push notification payload.
    * On Android, opens the chatbox by default when the user taps a notification.
    * On iOS, processes the payload through the Crisp SDK.
+   * Emits `messageReceived` with `fromPushNotification: true` for Crisp payloads,
+   * which lets apps update unread badges when the chatbox is closed.
    *
    * @param data - Notification payload
    * @param data.data - Key/value data from the push notification


### PR DESCRIPTION
## What
- Emit the existing `messageReceived` listener when a forwarded Crisp push payload is handled.
- Add `fromPushNotification` to `CrispMessageEvent` so apps can distinguish SDK callbacks from push-backed events.
- Document the foreground push forwarding path for unread badges.

## Why
- Follow-up to #179: the native SDK `messageReceived` callback only fires when Crisp delivers a chat event, which does not cover the common foreground push path while the chatbox is closed.
- The pinned iOS and Android SDK public APIs do not expose an unread-count getter/callback, so this uses the existing push-notification integration instead of inventing a fake count.

## How
- Android verifies the payload with `CrispNotificationClient.isCrispNotification`, handles it, then emits `messageReceived` when `openChatbox: false`.
- iOS verifies the raw payload with `CrispSDK._isRawCrispPushNotification`, handles it, then emits `messageReceived` for Crisp payloads.
- README shows forwarding `pushNotificationReceived` with `openChatbox: false` so the app can increment its unread badge and reset on `chatOpened`.

## Testing
- `bun run clean`
- `bun run docgen`
- `bunx tsc`
- `bunx rollup -c rollup.config.mjs`
- `bunx eslint .` (0 errors; existing warnings in `src/web.ts`)
- `bunx prettier-pretty-check "**/*.{css,html,ts,js,java}" --plugin=prettier-plugin-java --check`
- `bun run swiftlint -- lint` (exit 0; warnings from SwiftPM checkouts plus existing complexity warning)
- `cd android && ./gradlew clean build test`
- `bun run check:wiring`

## Not Tested
- Local iOS build: `xcodebuild -scheme CapgoCapacitorCrisp -destination generic/platform=iOS` is blocked on this machine because Xcode has no usable iOS 26.4 destination/runtime. Tried `generic/platform=iOS Simulator` with the same destination error. Mac Catalyst is not a valid fallback because Capacitor's SPM binary does not ship a Catalyst slice. CI must validate the iOS lane.