### PR TITLE
feat: Allow identity verification signature in setUser

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,15 +273,15 @@ Used to identify and restore previous conversations.
 ### setUser(...)
 
 ```typescript
-setUser(data: { nickname?: string; phone?: string; email?: string; avatar?: string; }) => Promise<void>
+setUser(data: { nickname?: string; phone?: string; email?: string; signature?: string; avatar?: string; }) => Promise<void>
 ```
 
 Set user information for the current session.
 Updates the user profile visible to support agents.
 
-| Param      | Type                                                                                 | Description               |
-| ---------- | ------------------------------------------------------------------------------------ | ------------------------- |
-| **`data`** | <code>{ nickname?: string; phone?: string; email?: string; avatar?: string; }</code> | - User information object |
+| Param      | Type                                                                                                     | Description               |
+| ---------- | -------------------------------------------------------------------------------------------------------- | ------------------------- |
+| **`data`** | <code>{ nickname?: string; phone?: string; email?: string; signature?: string; avatar?: string; }</code> | - User information object |
 
 --------------------
 

--- a/android/src/main/java/ee/forgr/plugin/crisp/CapacitorCrispPlugin.java
+++ b/android/src/main/java/ee/forgr/plugin/crisp/CapacitorCrispPlugin.java
@@ -186,7 +186,12 @@ public class CapacitorCrispPlugin extends Plugin {
     public void setUser(PluginCall call) {
         if (call.hasOption("email")) {
             String email = call.getString("email");
-            Crisp.setUserEmail(email);
+            String signature = call.getString("signature");
+            if (signature != null && !signature.isEmpty()) {
+                Crisp.setUserEmail(email, signature);
+            } else {
+                Crisp.setUserEmail(email);
+            }
         }
         if (call.hasOption("nickname")) {
             String nickname = call.getString("nickname");

--- a/ios/Sources/CapacitorCrispPlugin/CapacitorCrispPlugin.swift
+++ b/ios/Sources/CapacitorCrispPlugin/CapacitorCrispPlugin.swift
@@ -92,6 +92,7 @@ public class CapacitorCrispPlugin: CAPPlugin, CAPBridgedPlugin {
         let nickname = call.getString("nickname")
         let phone = call.getString("phone")
         let email = call.getString("email")
+        let signature = call.getString("signature")
         let avatar = call.getString("avatar")
 
         DispatchQueue.main.async {
@@ -103,6 +104,9 @@ public class CapacitorCrispPlugin: CAPPlugin, CAPBridgedPlugin {
             }
             if let email = email {
                 CrispSDK.user.email = email
+            }
+            if let signature = signature, !signature.isEmpty {
+                CrispSDK.user.signature = signature
             }
             if let avatar = avatar {
                 CrispSDK.user.avatar = URL(string: avatar)

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -107,6 +107,9 @@ export interface CapacitorCrispPlugin {
    * @param data.nickname - User's display name
    * @param data.phone - User's phone number
    * @param data.email - User's email address
+   * @param data.signature - Optional HMAC-SHA256 hex digest of the email for
+   *   [identity verification](https://docs.crisp.chat/guides/chatbox-sdks/web-sdk/identity-verification/).
+   *   Generate this on your backend with your Crisp secret key; never in the client.
    * @param data.avatar - URL to user's avatar image
    * @returns Promise that resolves when user info is updated
    * @example
@@ -114,11 +117,18 @@ export interface CapacitorCrispPlugin {
    * await CrispPlugin.setUser({
    *   nickname: 'John Doe',
    *   email: 'john@example.com',
+   *   signature: 'backend-generated-hmac-sha256-hex',
    *   phone: '+1234567890'
    * });
    * ```
    */
-  setUser(data: { nickname?: string; phone?: string; email?: string; avatar?: string }): Promise<void>;
+  setUser(data: {
+    nickname?: string;
+    phone?: string;
+    email?: string;
+    signature?: string;
+    avatar?: string;
+  }): Promise<void>;
 
   /**
    * Push a custom event to Crisp.

--- a/src/web.ts
+++ b/src/web.ts
@@ -103,12 +103,22 @@ export class CapacitorCrispWeb extends WebPlugin implements CapacitorCrispPlugin
     this.reset();
   }
 
-  async setUser(data: { nickname?: string; phone?: string; email?: string; avatar?: string }): Promise<void> {
+  async setUser(data: {
+    nickname?: string;
+    phone?: string;
+    email?: string;
+    signature?: string;
+    avatar?: string;
+  }): Promise<void> {
     if (data.nickname) {
       window.$crisp.push(['set', 'user:nickname', [data.nickname]]);
     }
     if (data.email) {
-      window.$crisp.push(['set', 'user:email', [data.email]]);
+      if (data.signature) {
+        window.$crisp.push(['set', 'user:email', [data.email, data.signature]]);
+      } else {
+        window.$crisp.push(['set', 'user:email', [data.email]]);
+      }
     }
     if (data.phone) {
       window.$crisp.push(['set', 'user:phone', [data.phone]]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Add optional `signature` to `setUser()` for Crisp [identity verification](https://docs.crisp.chat/guides/chatbox-sdks/web-sdk/identity-verification/)
- Wire it through web, Android, and iOS native implementations
- Regenerate API docs in README

## Why
- Fixes #187
- Crisp requires `$crisp.push(["set", "user:email", ["email", "signature"]])` (and native equivalents) to mark emails as verified
- Plugin previously only accepted email without signature

## How
- `src/definitions.ts`: optional `signature?: string` on `setUser` (backward compatible)
- Web: pass signature as second `user:email` arg when present
- Android: `Crisp.setUserEmail(email, signature)` when signature is non-empty
- iOS: set `CrispSDK.user.email` then `CrispSDK.user.signature`

## Testing
- `bun run build` (includes docgen)
- `bun run verify:web`
- `bun run lint` / `bun run fmt`
- Android/iOS native builds not run here (Linux environment; no Android SDK / Xcode)

## Not Tested
- Live Crisp dashboard verification with a real HMAC-SHA256 signature
- Native iOS/Android verify builds in CI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcc69-7c8e-7319-ab5e-7c2d7a850f5c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcc69-7c8e-7319-ab5e-7c2d7a850f5c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-crisp/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional user signature support when setting user details.
  * Signatures can be sent with email addresses for identity verification across web, Android, and iOS.
* **Documentation**
  * Updated API documentation and type definitions to include the optional signature field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->